### PR TITLE
cleanup: remove feature branch trigger from dev-builds workflow

### DIFF
--- a/.github/workflows/dev-builds.yml
+++ b/.github/workflows/dev-builds.yml
@@ -2,7 +2,7 @@ name: Development Builds
 
 on:
   push:
-    branches: [ main, develop, feature/MacOS-Implementation ]
+    branches: [ main, develop ]
     paths-ignore:
       - '*.md'
       - 'docs/**'


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for development builds to streamline branch targeting. The most important change is the removal of the `feature/MacOS-Implementation` branch from the list of branches that trigger the workflow.

### Workflow configuration updates:

* [`.github/workflows/dev-builds.yml`](diffhunk://#diff-4f264e4033511e74260709d6b1dde59efdd19796696b4fb5e5d4b43fc4ae148aL5-R5): Removed `feature/MacOS-Implementation` from the `branches` list under the `push` event configuration, ensuring the workflow only triggers on `main` and `develop` branches.