### PR TITLE
Fix: Extract version from main.py without importing tkinter for impro…

### DIFF
--- a/.github/workflows/smart-cicd.yml
+++ b/.github/workflows/smart-cicd.yml
@@ -75,7 +75,8 @@ jobs:
       id: get_version
       shell: bash
       run: |
-        VERSION=$(python -c "import sys; sys.path.append('.'); from main import VERSION; print(VERSION)")
+        # Extract VERSION without importing tkinter
+        VERSION=$(grep -E '^VERSION = ' main.py | sed 's/VERSION = "\(.*\)"/\1/')
         echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
         echo "App version: $VERSION"
     - name: Set virtual display (Linux only)
@@ -348,7 +349,8 @@ jobs:
     - name: Get version from main.py
       id: get_version
       run: |
-        VERSION=$(python -c "import sys; sys.path.append('.'); from main import VERSION; print(VERSION)")
+        # Extract VERSION without importing tkinter
+        VERSION=$(grep -E '^VERSION = ' main.py | sed 's/VERSION = "\(.*\)"/\1/')
         echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
         echo "Pre-release version: $VERSION"
     - name: Download all artifacts


### PR DESCRIPTION
This pull request updates the method for extracting the `VERSION` variable from `main.py` in the `.github/workflows/smart-cicd.yml` workflow file. The change avoids importing `tkinter`, which could cause unnecessary dependencies or errors during the CI/CD process.

### Workflow improvements:

* [`.github/workflows/smart-cicd.yml`](diffhunk://#diff-30fadab05c40d71acbe2a90493895a64f4f71b77d1d80f6564a8d5ef5107d425L78-R79): Replaced the Python-based method for extracting `VERSION` with a `grep` and `sed` command to avoid importing `tkinter`. This change is applied in two locations within the workflow file. [[1]](diffhunk://#diff-30fadab05c40d71acbe2a90493895a64f4f71b77d1d80f6564a8d5ef5107d425L78-R79) [[2]](diffhunk://#diff-30fadab05c40d71acbe2a90493895a64f4f71b77d1d80f6564a8d5ef5107d425L351-R353)…ved reliability